### PR TITLE
Merged ProfilePage changes, Datastore method update, doGet and doPost behavior change

### DIFF
--- a/src/main/java/codeu/controller/ProfilePageServlet.java
+++ b/src/main/java/codeu/controller/ProfilePageServlet.java
@@ -72,10 +72,7 @@ public class ProfilePageServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response)
     throws IOException, ServletException {
-      /* TODO 
-       * Send AboutMe, and Interests data to UserProfile object
-       * Update UserProfileStore with new UserProfile object. 
-       */
+      
       String username = (String) request.getSession().getAttribute("user");
       if (!userStore.isUserRegistered(username)) {
         request.setAttribute("error", "User is not registered");

--- a/src/main/java/codeu/controller/ProfilePageServlet.java
+++ b/src/main/java/codeu/controller/ProfilePageServlet.java
@@ -7,6 +7,7 @@ import codeu.model.store.basic.UserProfileStore;
 import java.time.Instant;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.UUID;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -76,28 +77,32 @@ public class ProfilePageServlet extends HttpServlet {
        * Update UserProfileStore with new UserProfile object. 
        */
       String username = (String) request.getSession().getAttribute("user");
-      if (userStore.isUserRegistered(username)) {
-        User user = userStore.getUser(username);
-        UserProfile userProfile = null;
-        String aboutMe = request.getParameter("aboutMe");
-        String profilePicture = request.getParameter("profilepicture");
-        String category = request.getParameter("myFavorites");
-        String subCategory = request.getParameter("subcategory");
-
-        if (userProfileStore.isUserProfileCreated(user.getId())) {
-          userProfile = userProfileStore.getUserProfile(user.getId());
-          userProfile.setLastTimeOnline(Instant.now());
-        }
-        else {
-          userProfile = new UserProfile(user.getId(), "", "", new HashMap<String, String>(), Instant.now());
-        }
-
-        userProfile.setAboutMe(aboutMe);
-        userProfile.setProfilePicture(profilePicture);
-        userProfile.addInterest(category, subCategory);
-
-        userProfileStore.addUserProfile(userProfile);
+      if (!userStore.isUserRegistered(username)) {
+        request.setAttribute("error", "User is not registered");
         request.getRequestDispatcher("/WEB-INF/view/profilepage.jsp").forward(request, response);
+        return;
       }
+      User user = userStore.getUser(username);
+      UUID userId = userStore.getUser(username).getId();
+      UserProfile userProfile = null;
+      String aboutMe = request.getParameter("aboutMe");
+      String profilePicture = request.getParameter("profilePicture");
+      String category = request.getParameter("myFavorites");
+      String subCategory = request.getParameter("subcategory");
+
+      if (userProfileStore.isUserProfileCreated(userId)) {
+        userProfile = userProfileStore.getUserProfile(userId);
+        userProfile.setLastTimeOnline(Instant.now());
+      }
+      else {
+        userProfile = new UserProfile(userId, "", "", new HashMap<String, String>(), Instant.now());
+      }
+
+      userProfile.setAboutMe(aboutMe);
+      userProfile.setProfilePicture(profilePicture);
+      userProfile.addInterest(category, subCategory);
+
+      userProfileStore.addUserProfile(userProfile);
+      request.getRequestDispatcher("/WEB-INF/view/profilepage.jsp").forward(request, response);
     } 
 }

--- a/src/main/java/codeu/controller/ProfilePageServlet.java
+++ b/src/main/java/codeu/controller/ProfilePageServlet.java
@@ -1,8 +1,12 @@
 package codeu.controller;
 
+import codeu.model.data.User;
+import codeu.model.data.UserProfile;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.basic.UserProfileStore;
+import java.time.Instant;
 import java.io.IOException;
+import java.util.HashMap;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -30,7 +34,7 @@ public class ProfilePageServlet extends HttpServlet {
 
   /**
    * Sets the UserStore used by this servlet. This function provides a common setup method for use
-   * by the test framework or the servlet's init() function.
+   * by the test framework or the servlet's init() function.  
    */
   void setUserStore(UserStore userStore) {
     this.userStore = userStore;
@@ -71,5 +75,29 @@ public class ProfilePageServlet extends HttpServlet {
        * Send AboutMe, and Interests data to UserProfile object
        * Update UserProfileStore with new UserProfile object. 
        */
+      String username = (String) request.getSession().getAttribute("user");
+      if (userStore.isUserRegistered(username)) {
+        User user = userStore.getUser(username);
+        UserProfile userProfile = null;
+        String aboutMe = request.getParameter("aboutMe");
+        String profilePicture = request.getParameter("profilepicture");
+        String category = request.getParameter("myFavorites");
+        String subCategory = request.getParameter("subcategory");
+
+        if (userProfileStore.isUserProfileCreated(user.getId())) {
+          userProfile = userProfileStore.getUserProfile(user.getId());
+          userProfile.setLastTimeOnline(Instant.now());
+        }
+        else {
+          userProfile = new UserProfile(user.getId(), "", "", new HashMap<String, String>(), Instant.now());
+        }
+
+        userProfile.setAboutMe(aboutMe);
+        userProfile.setProfilePicture(profilePicture);
+        userProfile.addInterest(category, subCategory);
+
+        userProfileStore.addUserProfile(userProfile);
+        request.getRequestDispatcher("/WEB-INF/view/profilepage.jsp").forward(request, response);
+      }
     } 
 }

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -9,6 +9,7 @@ import codeu.model.data.User;
 import codeu.model.data.UserProfile;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.basic.UserProfileStore;
+import java.util.HashMap;
 import java.util.UUID;
 import java.time.Instant;
 import org.mindrot.jbcrypt.BCrypt;
@@ -88,7 +89,9 @@ public class RegisterServlet extends HttpServlet {
     User user = new User(id, username, BCrypt.hashpw(password, BCrypt.gensalt()), current);
     userStore.addUser(user);
 
-    UserProfile profile = new UserProfile(id, "No about me yet", "https://i.imgur.com/z4amwTY.png", null, current);
+    HashMap<String, String> interests = new HashMap<>();
+
+    UserProfile profile = new UserProfile(id, "No about me yet", "https://i.imgur.com/z4amwTY.png", interests, current);
     profileStore.addUserProfile(profile); 
 
     response.sendRedirect("/login");

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -1,14 +1,18 @@
 package codeu.controller;
 
 import codeu.model.data.Conversation;
+import codeu.model.data.UserProfile;
 import codeu.model.data.Message;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserProfileStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.persistence.PersistentDataStoreException;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.List;
+import java.util.UUID;
+import java.util.Map;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
@@ -31,6 +35,9 @@ public class ServerStartupListener implements ServletContextListener {
       List<Message> messages = PersistentStorageAgent.getInstance().loadMessages();
       MessageStore.getInstance().setMessages(messages);
 
+      Map<UUID, UserProfile> userProfiles = PersistentStorageAgent.getInstance().loadUserProfiles();
+      UserProfileStore.getInstance().setUserProfiles(userProfiles);
+      
     } catch (PersistentDataStoreException e) {
       System.err.println("Server didn't start correctly. An error occurred during Datastore load!");
       System.err.println("This is usually caused by loading data that's in an invalid format.");

--- a/src/main/java/codeu/model/data/UserProfile.java
+++ b/src/main/java/codeu/model/data/UserProfile.java
@@ -58,7 +58,7 @@ public class UserProfile {
         return this.interests;
     }
 
-    public Instant getlastTimeOnline() {
+    public Instant getLastTimeOnline() {
         return this.lastTimeOnline;
     }
     

--- a/src/main/java/codeu/model/data/UserProfile.java
+++ b/src/main/java/codeu/model/data/UserProfile.java
@@ -17,6 +17,7 @@ package codeu.model.data;
 import java.util.Map;
 import java.time.Instant;
 import java.util.UUID;
+import com.google.appengine.api.datastore.Key;
 
 /** Class representing a registered user's profile. */
 public class UserProfile {
@@ -25,6 +26,7 @@ public class UserProfile {
     private String profilePicture;
     private Map<String,String> interests;
     private Instant lastTimeOnline;
+    private Key entityKey;
 
     /**
       * Constructs a new UserProfile.
@@ -61,6 +63,10 @@ public class UserProfile {
     public Instant getLastTimeOnline() {
         return this.lastTimeOnline;
     }
+
+    public Key getEntityKey() {
+        return this.entityKey;
+    }
     
     public void setAboutMe(String about){
         this.aboutMe = about;
@@ -71,15 +77,21 @@ public class UserProfile {
     }
 
     public void addInterest(String category, String interest){
-        if(interests.containsKey(category))
-            interests.put(category, interests.get(category) + ", " + interest);
+        if (category == null || category.length() == 0 || interest == null || interest.length() == 0) {
+            return;
+        }
         
+        if (interests.containsKey(category))
+            interests.put(category, interests.get(category) + ", " + interest);
         else
-        interests.put(category, interest);
-
+            interests.put(category, interest);
     }
 
     public void setLastTimeOnline(Instant time){
         this.lastTimeOnline = time;
+    }
+
+    public void setEntityKey(Key entityKey) {
+        this.entityKey = entityKey;
     }
 }

--- a/src/main/java/codeu/model/store/basic/UserProfileStore.java
+++ b/src/main/java/codeu/model/store/basic/UserProfileStore.java
@@ -15,6 +15,7 @@
 package codeu.model.store.basic;
 
 import codeu.model.data.UserProfile;
+import codeu.model.store.persistence.PersistentDataStoreException;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.HashMap;
 import java.util.UUID;

--- a/src/main/java/codeu/model/store/basic/UserProfileStore.java
+++ b/src/main/java/codeu/model/store/basic/UserProfileStore.java
@@ -75,8 +75,7 @@ public class UserProfileStore {
    * @return null if UUID does not match any existing UserProfile.
    */
   public UserProfile getUserProfile(UUID UUID) {
-    if (userProfiles.containsKey(UUID)) return userProfiles.get(UUID);
-    return null;
+    return userProfiles.get(UUID);
   }
 
 

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -210,7 +210,7 @@ public class PersistentDataStore {
       interestsEntity.setProperty(key, interests.get(key));
     }
     userProfileEntity.setProperty("interests", interestsEntity);
-    userProfileEntity.setProperty("last_time_online", userProfile.getlastTimeOnline().toString());
+    userProfileEntity.setProperty("last_time_online", userProfile.getLastTimeOnline().toString());
     datastore.put(userProfileEntity);
   }
 

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -21,6 +21,7 @@ import codeu.model.data.User;
 import codeu.model.store.persistence.PersistentDataStoreException;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.EmbeddedEntity;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
@@ -168,7 +169,11 @@ public class PersistentDataStore {
         UUID uuid = UUID.fromString((String) entity.getProperty("uuid"));
         String aboutMe = (String) entity.getProperty("aboutMe");
         String profilePicture = (String) entity.getProperty("profilePicture");
-        Map<String, String> interests = (Map<String, String>) entity.getProperty("interests");
+        Map<String, String> interests = new HashMap<>();
+        EmbeddedEntity interestsEntity = (EmbeddedEntity) entity.getProperty("interests");
+        for (String key : interestsEntity.getProperties().keySet()) {
+          interests.put(key, (String) interestsEntity.getProperty(key));
+        }
         Instant creationTime = Instant.parse((String) entity.getProperty("last_time_online"));
         UserProfile userProfile = new UserProfile(uuid, aboutMe, profilePicture, interests, creationTime);
         userProfiles.put(uuid, userProfile);
@@ -199,7 +204,12 @@ public class PersistentDataStore {
     userProfileEntity.setProperty("uuid", userProfile.getId().toString());
     userProfileEntity.setProperty("aboutMe", userProfile.getAboutMe());
     userProfileEntity.setProperty("profilePicture", userProfile.getProfilePicture());
-    userProfileEntity.setProperty("interests", userProfile.getInterests());
+    EmbeddedEntity interestsEntity = new EmbeddedEntity();
+    Map<String, String> interests = userProfile.getInterests();
+    for (String key : interests.keySet()) {
+      interestsEntity.setProperty(key, interests.get(key));
+    }
+    userProfileEntity.setProperty("interests", interestsEntity);
     userProfileEntity.setProperty("last_time_online", userProfile.getlastTimeOnline().toString());
     datastore.put(userProfileEntity);
   }

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -102,6 +102,27 @@ public class PersistentStorageAgent {
     return persistentDataStore.loadUserProfiles();
   }
 
+  /**
+   * Delete all UserProfile objects from the Datastore service.
+   * 
+   * @throws PersistentDataStoreException if an error was detected during the load from the
+   *     Datastore service
+   */
+  public void deleteUserProfiles() throws PersistentDataStoreException {
+    persistentDataStore.deleteUserProfiles();
+  }
+
+  /**
+   * Delete all UserProfile objects with the given uuid from the Datastore service.
+   * 
+   * @param uuid The UUID of the User Profile objects to be deleted.
+   * @throws PersistentDataStoreException if an error was detected during the load from the
+   *     Datastore service
+   */
+  public void deleteUserProfiles(UUID uuid) throws PersistentDataStoreException {
+    persistentDataStore.deleteUserProfiles(uuid);
+  }
+
   /** Write a User object to the Datastore service. */
   public void writeThrough(User user) {
     persistentDataStore.writeThrough(user);
@@ -116,7 +137,7 @@ public class PersistentStorageAgent {
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);
   }
-/** Write a Conversation object to the Datastore service. */
+/** Write a UserProfile object to the Datastore service. */
   public void writeThrough(UserProfile userProfile) {
     persistentDataStore.writeThrough(userProfile);
   }

--- a/src/main/webapp/WEB-INF/view/profilepage.jsp
+++ b/src/main/webapp/WEB-INF/view/profilepage.jsp
@@ -2,59 +2,52 @@
 <!DOCTYPE html>
 <html>
 <head>
- <%@include file="navigationbar.jsp" %>
- <title>Profile Page</title>
- <link rel="stylesheet" href="/css/main.css">
- <link rel="stylesheet" href="/css/profilepage.css">
+    <%@include file="navigationbar.jsp" %>
+    <title>Profile Page</title>
+    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/css/profilepage.css">
 </head>
 <body>
-         <div id="leftContainer">
-          <h1>
-            <% if(request.getSession().getAttribute("user") != null){ %>
-                <%= request.getSession().getAttribute("user") %>'s 
-            <% } %>
-            Profile Page</h1>
+    <div id="leftContainer">
+        <h1>
+        <% if(request.getSession().getAttribute("user") != null){ %>
+            <%= request.getSession().getAttribute("user") %>'s 
+        <% } %>
+        Profile Page</h1>
 
-             
-           
-            <form action="/profilepage">
-              <input type = "submit" value = "Update Profile">
-              <br/>
-                      <img id="profilePicture" src="https://i.imgur.com/z4amwTY.png">
+        <form action="/profilepage">
+            <input type="submit" value="Update Profile">
+            <br/>
+                <img name="profilePicture" id="profilePicture" src="https://i.imgur.com/z4amwTY.png">
             <br/><br/>
-            
+
             <select name="myFavorites" id="selector">
-                  <option value="Books">Book</option>
-                  <option value="Food">Food</option>
-                  <option value="Hobbies">Hobbies</option>
-                  <option value="Movies">Movies</option>
-                  <option value="Songs">Songs</option>
-                  <option value="Sports">Sports</option>
-                  <option value="TV Shows">Tv Shows</option>
+                    <option value="Books">Book</option>
+                    <option value="Food">Food</option>
+                    <option value="Hobbies">Hobbies</option>
+                    <option value="Movies">Movies</option>
+                    <option value="Songs">Songs</option>
+                    <option value="Sports">Sports</option>
+                    <option value="TV Shows">Tv Shows</option>
             </select>
             <br/>
-            <input type= "text" name="subcategory">
+            <input type="text" name="subcategory">
             <br/>
             <h2>Interests</h2>
-            <div id = "interestBlock">
-              Interests will go in here/be updated in here
+            <div id="interestBlock">
+                Interests will go in here/be updated in here
             </div>
-           
-        </center>
-        </div>
-        <div id="midContainer">
+            </center>
+    </div>
+    <div id="midContainer">
         
-             <h1>About Me</h1>
-             <textarea name ="aboutMe" id="aboutMe" rows='10' cols='90'></textarea>
-             
-             <br/>
-            </form>
-      
-        
-            <h1>Recent Activity</h1>
-            <textarea id="activity" rows='20' cols='90'></textarea>
-        </div>
+            <h1>About Me</h1>
+            <textarea name="aboutMe" id="aboutMe" rows='10' cols='90'></textarea>
+            <br/>
+        </form>
 
-   
+        <h1>Recent Activity</h1>
+        <textarea name="activity" id="activity" rows='20' cols='90'></textarea>
+    </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/profilepage.jsp
+++ b/src/main/webapp/WEB-INF/view/profilepage.jsp
@@ -1,4 +1,5 @@
 <%@ page import="codeu.model.data.User" %>
+<%@ page import="java.util.HashMap" %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -15,12 +16,25 @@
         <% } %>
         Profile Page</h1>
 
-        <form action="/profilepage">
-            <input type="submit" value="Update Profile">
+        <form action="/profilepage" method="POST">
+            <img name="profilePicture" id="profilePicture" src="https://i.imgur.com/z4amwTY.png">
             <br/>
-                <img name="profilePicture" id="profilePicture" src="https://i.imgur.com/z4amwTY.png">
-            <br/><br/>
-
+            
+            <input type="submit" value="Update Profile">
+            <input name="resetProfile" id="resetCheck" type="checkbox">
+            <label for="resetCheck">Reset Profile?</label>
+            <br/>
+            <h2>
+                Last time online: 
+                <%
+                    if (request.getSession().getAttribute("lastTimeOnline") != null) {
+                        out.print(request.getSession().getAttribute("lastTimeOnline"));
+                    }
+                    else {
+                        out.print("unknown");
+                    }
+                %>
+            </h2>
             <select name="myFavorites" id="selector">
                     <option value="Books">Book</option>
                     <option value="Food">Food</option>
@@ -36,13 +50,24 @@
             <h2>Interests</h2>
             <div id="interestBlock">
                 Interests will go in here/be updated in here
+                <%
+                if (request.getSession().getAttribute("interests") != null) {
+                    HashMap<String, String> interests = (HashMap<String,String>) request.getSession().getAttribute("interests");
+                    for (String interest : interests.keySet()) {
+                        out.print(interest + ": " + interests.get(interest) + "<br/>");
+                    }
+                }
+                %>
             </div>
             </center>
     </div>
     <div id="midContainer">
-        
             <h1>About Me</h1>
-            <textarea name="aboutMe" id="aboutMe" rows='10' cols='90'></textarea>
+            <textarea name="aboutMe" id="aboutMe" rows='10' cols='90'><% 
+                if(request.getSession().getAttribute("aboutMe") != null) { 
+                    out.print(request.getSession().getAttribute("aboutMe"));
+                } 
+                %></textarea>
             <br/>
         </form>
 

--- a/src/test/java/codeu/controller/ProfilePageServletTest.java
+++ b/src/test/java/codeu/controller/ProfilePageServletTest.java
@@ -5,29 +5,125 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.HashMap;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mindrot.jbcrypt.BCrypt;
+import org.mockito.ArgumentCaptor;
+import codeu.model.data.User;
+import codeu.model.data.UserProfile;
+import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.UserProfileStore;
 
 
 public class ProfilePageServletTest {
 
   private ProfilePageServlet profilePageServlet;
-  private HttpServletRequest mockRequest;
+  private HttpServletRequest mockRequest;  
   private HttpServletResponse mockResponse;
   private RequestDispatcher mockRequestDispatcher;
-  @Before
+  private HttpSession mockSession;
+  private UserStore mockUserStore;
+  private UserProfileStore mockUserProfileStore;
+
+  @Before  
   public void setup() {
     profilePageServlet = new ProfilePageServlet();
-    mockRequest = Mockito.mock(HttpServletRequest.class);
-    mockResponse = Mockito.mock(HttpServletResponse.class);
+    mockRequest = Mockito.mock(HttpServletRequest.class); 
+    mockResponse = Mockito.mock(HttpServletResponse.class); 
     mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
     Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/profilepage.jsp")).thenReturn(mockRequestDispatcher);
+
+    mockSession = Mockito.mock(HttpSession.class);
+    Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+
+    mockUserStore = Mockito.mock(UserStore.class);
+    profilePageServlet.setUserStore(mockUserStore);
+
+    mockUserProfileStore = Mockito.mock(UserProfileStore.class);
+    profilePageServlet.setUserProfileStore(mockUserProfileStore);
+
+    }
+
+  @Test
+  public void testDoGet() throws IOException, ServletException {  
+    profilePageServlet.doGet(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 
   @Test
-  public void testDoGet() throws IOException, ServletException {
-    profilePageServlet.doGet(mockRequest, mockResponse);
+  public void testDoPost_UpdateExistingUserProfile() throws IOException, ServletException{
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test username");
+    Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);
+
+    UUID mockId = UUID.randomUUID();
+    User mockUser = new User(mockId, "test username", BCrypt.hashpw("test password", BCrypt.gensalt()), Instant.now());
+    
+    Mockito.when(mockUserStore.getUser("test username")).thenReturn(mockUser);  
+
+    Mockito.when(mockRequest.getParameter("aboutMe")).thenReturn("test_aboutMe");
+    Mockito.when(mockRequest.getParameter("profilePicture")).thenReturn("test_profilePicture");
+    Mockito.when(mockRequest.getParameter("myFavorites")).thenReturn("test_category");
+    Mockito.when(mockRequest.getParameter("subcategory")).thenReturn("test_subcategory");
+
+    Mockito.when(mockUserProfileStore.isUserProfileCreated(mockId)).thenReturn(true);
+
+    UserProfile mockUserProfile = new UserProfile(mockId, "", "", new HashMap<String, String>(), Instant.now());
+    Mockito.when(mockUserProfileStore.getUserProfile(mockId)).thenReturn(mockUserProfile);
+
+    profilePageServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<UserProfile> userProfileArgumentCaptor = ArgumentCaptor.forClass(UserProfile.class);
+    Mockito.verify(mockUserProfileStore).addUserProfile(userProfileArgumentCaptor.capture());
+    mockUserProfile = userProfileArgumentCaptor.getValue();
+
+    Assert.assertEquals(mockUserProfile.getId(), mockId);
+    Assert.assertEquals(mockUserProfile.getAboutMe(), "test_aboutMe");
+    Assert.assertEquals(mockUserProfile.getProfilePicture(), "test_profilePicture");
+    Assert.assertNotEquals(mockUserProfile.getInterests(), null);
+    Assert.assertEquals(mockUserProfile.getInterests().get("test_category"), "test_subcategory");
+    Assert.assertNotEquals(mockUserProfile.getLastTimeOnline(), null);
+
+    Assert.assertEquals(mockUserProfileStore.getUserProfile(mockId), mockUserProfile);
+
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
+  public void testDoPost_UpdateNewUserProfile() throws IOException, ServletException{
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test username");
+    Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);
+
+    UUID mockId = UUID.randomUUID();
+    User mockUser = new User(mockId, "test username", BCrypt.hashpw("test password", BCrypt.gensalt()), Instant.now());
+    
+    Mockito.when(mockUserStore.getUser("test username")).thenReturn(mockUser);  
+
+    Mockito.when(mockRequest.getParameter("aboutMe")).thenReturn("test_aboutMe");
+    Mockito.when(mockRequest.getParameter("profilePicture")).thenReturn("test_profilePicture");
+    Mockito.when(mockRequest.getParameter("myFavorites")).thenReturn("test_category");
+    Mockito.when(mockRequest.getParameter("subcategory")).thenReturn("test_subcategory");
+
+    Mockito.when(mockUserProfileStore.isUserProfileCreated(mockId)).thenReturn(false);
+
+    profilePageServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<UserProfile> userProfileArgumentCaptor = ArgumentCaptor.forClass(UserProfile.class);
+    Mockito.verify(mockUserProfileStore).addUserProfile(userProfileArgumentCaptor.capture());
+    UserProfile mockUserProfile = userProfileArgumentCaptor.getValue();
+
+    Assert.assertEquals(mockUserProfile.getId(), mockId);
+    Assert.assertEquals(mockUserProfile.getAboutMe(), "test_aboutMe");
+    Assert.assertEquals(mockUserProfile.getProfilePicture(), "test_profilePicture");
+    Assert.assertNotEquals(mockUserProfile.getInterests(), null);
+    Assert.assertEquals(mockUserProfile.getInterests().get("test_category"), "test_subcategory");
+    Assert.assertNotEquals(mockUserProfile.getLastTimeOnline(), null);
 
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }

--- a/src/test/java/codeu/controller/ProfilePageServletTest.java
+++ b/src/test/java/codeu/controller/ProfilePageServletTest.java
@@ -1,5 +1,7 @@
 package codeu.controller;
 
+import static org.junit.Assume.assumeFalse;
+
 import java.io.IOException;
 import java.util.UUID;
 import java.util.Map;
@@ -8,7 +10,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-<<<<<<< HEAD
 import java.time.Instant;
 import java.util.UUID;
 import java.util.HashMap;
@@ -18,22 +19,12 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.ArgumentCaptor;
-=======
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-import java.time.Instant;
-import java.util.Map;
->>>>>>> 2ce4bc31dd6fe59bcd9f01c63a272673db692783
 import codeu.model.data.User;
 import codeu.model.data.UserProfile;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.basic.UserProfileStore;
-<<<<<<< HEAD
-=======
 import java.util.HashMap;
 
->>>>>>> 2ce4bc31dd6fe59bcd9f01c63a272673db692783
 
 
 public class ProfilePageServletTest {
@@ -54,7 +45,8 @@ public class ProfilePageServletTest {
     mockResponse = Mockito.mock(HttpServletResponse.class); 
     mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
     Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/profilepage.jsp")).thenReturn(mockRequestDispatcher);
-
+    Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/login.jsp")).thenReturn(mockRequestDispatcher);
+    
     mockSession = Mockito.mock(HttpSession.class);
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
 
@@ -66,7 +58,7 @@ public class ProfilePageServletTest {
   }
 
   @Test
-  public void testDoGet() throws IOException, ServletException {
+  public void testDoGet_UserExists() throws IOException, ServletException {
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
     profilePageServlet.setUserStore(mockUserStore);
     profilePageServlet.setUserProfileStore(mockProfileStore);
@@ -76,20 +68,73 @@ public class ProfilePageServletTest {
     Instant current = Instant.now();
     Map<String,String> fakeInterests = new HashMap<String, String>();
     fakeInterests.put("test_category", "test_interest");
-    User fakeuser = new User(fakeUUID, "test_username", "password", current);
+    User fakeUser = new User(fakeUUID, "test_username", "password", current);
     UserProfile fakeprofile = new UserProfile(fakeUUID, "test_about", "picture_url", fakeInterests, current);
 
-    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeuser); //
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+    Mockito.when(mockProfileStore.isUserProfileCreated(fakeUUID)).thenReturn(true);
+
     Mockito.when(mockProfileStore.getUserProfile(fakeUUID)).thenReturn(fakeprofile);
 
-    profilePageServlet.doGet(mockRequest, mockResponse); //
-    Mockito.verify(mockRequest).setAttribute("interests", fakeInterests);
-    Mockito.verify(mockRequest).setAttribute("aboutMe", "test_about");
-    Mockito.verify(mockRequest).setAttribute("profilePic", "picture_url");
+    profilePageServlet.doGet(mockRequest, mockResponse); 
+    Mockito.verify(mockSession).setAttribute("interests", fakeInterests);
+    Mockito.verify(mockSession).setAttribute("aboutMe", "test_about");
+    Mockito.verify(mockSession).setAttribute("profilePic", "picture_url");
+    Mockito.verify(mockSession).setAttribute("lastTimeOnline", current);
 
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 
+  @Test
+  public void testDoGet_UserNotLoggedIn() throws IOException, ServletException{
+    Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+    
+    Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
+
+    profilePageServlet.doGet(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequest).setAttribute("error", "That username doesn't exist");
+    Mockito.verify(mockResponse).sendRedirect("/login");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+
+  }
+
+   @Test
+  public void testDoGet_UserDoesntExist() throws IOException, ServletException{
+    Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+    profilePageServlet.setUserStore(mockUserStore);
+
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(null); 
+
+    profilePageServlet.doGet(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequest).setAttribute("error", "Username not found");
+    Mockito.verify(mockResponse).sendRedirect("/login");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+
+  }
+
+  @Test
+  public void testDoGet_UserProfileDoesntExist() throws IOException, ServletException{
+    Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+    profilePageServlet.setUserStore(mockUserStore);
+
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    UUID fakeUUID = UUID.randomUUID();
+    Instant current = Instant.now();
+    User fakeUser = new User(fakeUUID, "test_username", "password", current);
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser); 
+    Mockito.when(mockProfileStore.isUserProfileCreated(fakeUUID)).thenReturn(false);
+
+    profilePageServlet.doGet(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequest).setAttribute("error", "User does not have a profile saved yet");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+
+  }
+  
   @Test
   public void testDoPost_UpdateExistingUserProfile() throws IOException, ServletException{
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test username");
@@ -157,6 +202,18 @@ public class ProfilePageServletTest {
     Assert.assertNotEquals(mockUserProfile.getInterests(), null);
     Assert.assertEquals(mockUserProfile.getInterests().get("test_category"), "test_subcategory");
     Assert.assertNotEquals(mockUserProfile.getLastTimeOnline(), null);
+
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+  
+  public void testDoPost_UserIsNotRegistered() throws IOException, ServletException{
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test username");
+    Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(false);
+
+    profilePageServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequest).setAttribute("error", "User is not registered");
+    Mockito.verify(mockResponse).sendRedirect("/login");
 
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }

--- a/src/test/java/codeu/controller/RegisterServletTest.java
+++ b/src/test/java/codeu/controller/RegisterServletTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import codeu.model.data.User;
+import codeu.model.data.UserProfile;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.basic.UserProfileStore;
 import org.mindrot.jbcrypt.BCrypt;
@@ -78,10 +79,14 @@ public class RegisterServletTest {
     Mockito.verify(mockPrintWriter).println("<p>Password: password</p>");
 
     ArgumentCaptor<User> userArgumentCaptor = ArgumentCaptor.forClass(User.class);
+    ArgumentCaptor<UserProfile> profileArgumentCaptor = ArgumentCaptor.forClass(UserProfile.class);
 
     Mockito.verify(mockUserStore).addUser(userArgumentCaptor.capture()); 
     User storedUser = userArgumentCaptor.getValue();
-    Assert.assertEquals(storedUser.getName(), "Testertest");
+
+    Mockito.verify(mockUserProfileStore).addUserProfile(profileArgumentCaptor.capture()); 
+    UserProfile storedProfile = profileArgumentCaptor.getValue();
+    Assert.assertEquals(storedProfile.getId(), storedUser.getId());
 
     //BCrypt.checkpw() checks that the second param is correctly hashed  
     Assert.assertTrue(BCrypt.checkpw("password", storedUser.getPassword()));  

--- a/src/test/java/codeu/model/data/UserProfileTest.java
+++ b/src/test/java/codeu/model/data/UserProfileTest.java
@@ -38,7 +38,7 @@ public class UserProfileTest {
     Assert.assertEquals(aboutMe, userProfile.getAboutMe());
     Assert.assertEquals(profilePicture, userProfile.getProfilePicture());
     Assert.assertEquals(interests, userProfile.getInterests()); 
-    Assert.assertEquals(lastTimeOnline, userProfile.getlastTimeOnline());
+    Assert.assertEquals(lastTimeOnline, userProfile.getLastTimeOnline());
   }
 
 
@@ -69,6 +69,6 @@ public class UserProfileTest {
     Assert.assertEquals(newAboutMe, userProfile.getAboutMe());
     Assert.assertEquals(newProfilePicture, userProfile.getProfilePicture());
     Assert.assertEquals(interests, userProfile.getInterests()); 
-    Assert.assertEquals(newTimeOnline, userProfile.getlastTimeOnline());
+    Assert.assertEquals(newTimeOnline, userProfile.getLastTimeOnline());
   }
 }

--- a/src/test/java/codeu/model/store/basic/UserProfileStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/UserProfileStoreTest.java
@@ -81,6 +81,6 @@ public class UserProfileStoreTest {
     Assert.assertEquals(expectedUserProfile.getAboutMe(), actualUserProfile.getAboutMe());
     Assert.assertEquals(expectedUserProfile.getProfilePicture(), actualUserProfile.getProfilePicture());
     Assert.assertEquals(expectedUserProfile.getInterests(), actualUserProfile.getInterests());
-    Assert.assertEquals(expectedUserProfile.getlastTimeOnline(), expectedUserProfile.getlastTimeOnline());
+    Assert.assertEquals(expectedUserProfile.getLastTimeOnline(), expectedUserProfile.getLastTimeOnline());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -174,13 +174,13 @@ public class PersistentDataStoreTest {
     Assert.assertEquals("test_aboutMe_one", resultUserProfileOne.getAboutMe());
     Assert.assertEquals("test_profilePicture_one", resultUserProfileOne.getProfilePicture());
     Assert.assertEquals(interestsOne, resultUserProfileOne.getInterests());
-    Assert.assertEquals(lastTimeOnlineOne, resultUserProfileOne.getlastTimeOnline());
+    Assert.assertEquals(lastTimeOnlineOne, resultUserProfileOne.getLastTimeOnline());
 
     UserProfile resultUserProfileTwo = resultUsers.get(idOne);
     Assert.assertEquals(idTwo, resultUserProfileTwo.getId());
     Assert.assertEquals("test_aboutMe_two", resultUserProfileTwo.getAboutMe());
     Assert.assertEquals("test_profilePicture_two", resultUserProfileTwo.getProfilePicture());
     Assert.assertEquals(interestsTwo, resultUserProfileTwo.getInterests());
-    Assert.assertEquals(lastTimeOnlineTwo, resultUserProfileTwo.getlastTimeOnline());
+    Assert.assertEquals(lastTimeOnlineTwo, resultUserProfileTwo.getLastTimeOnline());
   }
 }


### PR DESCRIPTION
Whew, this is a big commit. I didn't expect this to be so involved.
Theres a lot of changes but i think the most major is that the PersistentDataStore class now has a method to delete all UserProfiles and delete all UserProfiles of a given UUID. 
The writethrough is also updated to get the entityKey of the UserProfile it is writing and update that entity (this was to avoid the repeated copies of an entity that was an issue before)

The doGet and doPost now redirect users to the appropriate page when an error occurs.
Theres also a Reset Profile checkbox now to reset the entire profile page.
The doGet wasn't importing the Last Time Online so i added that.

The tests were the hardest things to deal with but they should be testing all aspects of each page now. I've added 2 more doPost tests and merged Cait's doGet tests (and updated to the new servlet changes).

Finally, i realized the startupListener was not initializing the UserProfileStore so i wasn't able to preload any data, so i added that there as well.

An example of the new checkbox in the UI:
![image](https://user-images.githubusercontent.com/13299847/39402336-7959aa82-4b2a-11e8-8d47-b6b967419248.png)
