### PR TITLE
Viewing User Profile pages by URL and not being the logged in user

### DIFF
--- a/src/main/java/codeu/controller/ProfilePageServlet.java
+++ b/src/main/java/codeu/controller/ProfilePageServlet.java
@@ -62,6 +62,11 @@ public class ProfilePageServlet extends HttpServlet {
     throws IOException, ServletException { 
 
     String username = (String)request.getSession().getAttribute("user"); 
+    String requestUrl = request.getRequestURI();
+    String profileUsername = requestUrl.substring("/profilepage/".length());
+    if (profileUsername != null && profileUsername.length() > 0) {
+      username = profileUsername;
+    }
     if(username == null){
       request.setAttribute("error", "That username doesn't exist");
       response.sendRedirect("/login");
@@ -118,7 +123,7 @@ public class ProfilePageServlet extends HttpServlet {
       UUID userId = userStore.getUser(username).getId();
       UserProfile userProfile = null;
       String resetProfile = request.getParameter("resetProfile");
-      
+
       if (userProfileStore.isUserProfileCreated(userId) && resetProfile == null) {
         userProfile = userProfileStore.getUserProfile(userId);
       }

--- a/src/main/java/codeu/controller/ProfilePageServlet.java
+++ b/src/main/java/codeu/controller/ProfilePageServlet.java
@@ -142,7 +142,7 @@ public class ProfilePageServlet extends HttpServlet {
       userProfile.addInterest(category, subCategory);
 
       userProfileStore.addUserProfile(userProfile);
-      response.sendRedirect("/profilepage");
+      response.sendRedirect("/profilepage/");
       request.getRequestDispatcher("/WEB-INF/view/profilepage.jsp").forward(request, response);
     } 
 }

--- a/src/main/webapp/WEB-INF/view/navigationbar.jsp
+++ b/src/main/webapp/WEB-INF/view/navigationbar.jsp
@@ -4,7 +4,7 @@
     <a href="/conversations">Conversations</a>
     <% if(request.getSession().getAttribute("user") != null){ %>
       <a>Hello <%= request.getSession().getAttribute("user") %>!</a>
-      <a href="/profilepage">My Profile</a>
+      <a href="/profilepage/">My Profile</a>
     <% } else{ %>
       <a href="/login">Login</a>
       <a href="/register">Register</a>

--- a/src/main/webapp/WEB-INF/view/profilepage.jsp
+++ b/src/main/webapp/WEB-INF/view/profilepage.jsp
@@ -16,7 +16,7 @@
         <% } %>
         Profile Page</h1>
 
-        <form action="/profilepage" method="POST">
+        <form action="/profilepage/" method="POST">
             <img name="profilePicture" id="profilePicture" src="https://i.imgur.com/z4amwTY.png">
             <br/>
             

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -83,7 +83,7 @@
 
   <servlet-mapping>
     <servlet-name>ProfilePageServlet</servlet-name>
-    <url-pattern>/profilepage</url-pattern>
+    <url-pattern>/profilepage/*</url-pattern>
   </servlet-mapping>
   
 </web-app>

--- a/src/test/java/codeu/controller/ProfilePageServletTest.java
+++ b/src/test/java/codeu/controller/ProfilePageServletTest.java
@@ -63,6 +63,36 @@ public class ProfilePageServletTest {
     profilePageServlet.setUserStore(mockUserStore);
     profilePageServlet.setUserProfileStore(mockProfileStore);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/profilepage/");
+
+    UUID fakeUUID = UUID.randomUUID();
+    Instant current = Instant.now();
+    Map<String,String> fakeInterests = new HashMap<String, String>();
+    fakeInterests.put("test_category", "test_interest");
+    User fakeUser = new User(fakeUUID, "test_username", "password", current);
+    UserProfile fakeprofile = new UserProfile(fakeUUID, "test_about", "picture_url", fakeInterests, current);
+
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+    Mockito.when(mockProfileStore.isUserProfileCreated(fakeUUID)).thenReturn(true);
+
+    Mockito.when(mockProfileStore.getUserProfile(fakeUUID)).thenReturn(fakeprofile);
+
+    profilePageServlet.doGet(mockRequest, mockResponse); 
+    Mockito.verify(mockSession).setAttribute("interests", fakeInterests);
+    Mockito.verify(mockSession).setAttribute("aboutMe", "test_about");
+    Mockito.verify(mockSession).setAttribute("profilePic", "picture_url");
+    Mockito.verify(mockSession).setAttribute("lastTimeOnline", current);
+
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
+  public void testDoGet_ExternalUser() throws IOException, ServletException {
+    Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+    profilePageServlet.setUserStore(mockUserStore);
+    profilePageServlet.setUserProfileStore(mockProfileStore);
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("");
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/profilepage/test_username");
 
     UUID fakeUUID = UUID.randomUUID();
     Instant current = Instant.now();
@@ -88,8 +118,8 @@ public class ProfilePageServletTest {
   @Test
   public void testDoGet_UserNotLoggedIn() throws IOException, ServletException{
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
-    
     Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/profilepage/");
 
     profilePageServlet.doGet(mockRequest, mockResponse);
 
@@ -103,9 +133,10 @@ public class ProfilePageServletTest {
   public void testDoGet_UserDoesntExist() throws IOException, ServletException{
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
     profilePageServlet.setUserStore(mockUserStore);
-
+    
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(null); 
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/profilepage/");
 
     profilePageServlet.doGet(mockRequest, mockResponse);
 
@@ -121,6 +152,7 @@ public class ProfilePageServletTest {
     profilePageServlet.setUserStore(mockUserStore);
 
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/profilepage/");
 
     UUID fakeUUID = UUID.randomUUID();
     Instant current = Instant.now();


### PR DESCRIPTION
To access UserProfiles it is now /profilepage/optional_username_goes_here
Ex. /profilepage/test_user
If no username is added, then if the user is logged in, the default is their profile, if the user isn't logged in and no username is added to the url, then they get an error and are redirected to the login page.

I have also updated the tests for getting the username out of the url